### PR TITLE
Add base gems

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# Database url
+DATABASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignores local tests results
+spec/examples.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignores local tests results
 spec/examples.txt
+
+# Ignores local environment variables
+.env

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,33 @@
+AllCops:
+  Exclude:
+    - '.git/**/*'
+
+# Layout
+Layout/LineLength:
+  Max: 100
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+# Lint
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+# Style
+Style/Documentation:
+  Enabled: false
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,15 @@ ruby '2.7.0'
 
 gem 'sinatra', '~> 2.0.8.1'
 
-
 group :development, :test do
   gem 'pry', '~> 0.12.2'
 end
 
 group :development do
   gem 'rubocop', '~> 0.82.0', require: false
+end
+
+group :test do
+  gem 'rack-test', '~> 1.1.0'
+  gem 'rspec', '~> 3.9.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development do
 end
 
 group :test do
+  gem 'database_cleaner-active_record', '~> 1.8.0'
   gem 'rack-test', '~> 1.1.0'
   gem 'rspec', '~> 3.9.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.7.0'
 gem 'sinatra', '~> 2.0.8.1'
 
 group :development, :test do
+  gem 'dotenv', '~> 2.7.5'
   gem 'pry', '~> 0.12.2'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,10 @@ source 'https://rubygems.org'
 
 ruby '2.7.0'
 
+gem 'pg', '~> 1.2.3'
+gem 'rake', '~> 13.0.1'
 gem 'sinatra', '~> 2.0.8.1'
+gem 'sinatra-activerecord', '~> 2.0.18'
 
 group :development, :test do
   gem 'dotenv', '~> 2.7.5'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,11 @@ ruby '2.7.0'
 
 gem 'sinatra', '~> 2.0.8.1'
 
+
+group :development, :test do
+  gem 'pry', '~> 0.12.2'
+end
+
 group :development do
   gem 'rubocop', '~> 0.82.0', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 ruby '2.7.0'
 
 gem 'sinatra', '~> 2.0.8.1'
+
+group :development do
+  gem 'rubocop', '~> 0.82.0', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    coderay (1.1.2)
     jaro_winkler (1.5.4)
+    method_source (0.9.2)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
@@ -35,6 +40,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry (~> 0.12.2)
   rubocop (~> 0.82.0)
   sinatra (~> 2.0.8.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
+    dotenv (2.7.5)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
     mustermann (1.1.1)
@@ -56,6 +57,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv (~> 2.7.5)
   pry (~> 0.12.2)
   rack-test (~> 1.1.0)
   rspec (~> 3.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     ast (2.4.0)
     coderay (1.1.2)
+    diff-lcs (1.3)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
     mustermann (1.1.1)
@@ -16,8 +17,23 @@ GEM
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
     rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -41,6 +57,8 @@ PLATFORMS
 
 DEPENDENCIES
   pry (~> 0.12.2)
+  rack-test (~> 1.1.0)
+  rspec (~> 3.9.0)
   rubocop (~> 0.82.0)
   sinatra (~> 2.0.8.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.0)
+    jaro_winkler (1.5.4)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    parallel (1.19.1)
+    parser (2.7.1.1)
+      ast (~> 2.4.0)
     rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
+    rainbow (3.0.0)
+    rexml (3.2.4)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
@@ -13,11 +29,13 @@ GEM
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     tilt (2.0.10)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rubocop (~> 0.82.0)
   sinatra (~> 2.0.8.1)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,10 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    database_cleaner (1.8.4)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     dotenv (2.7.5)
     i18n (1.8.2)
@@ -81,6 +85,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  database_cleaner-active_record (~> 1.8.0)
   dotenv (~> 2.7.5)
   pg (~> 1.2.3)
   pry (~> 0.12.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.0.2.2)
+      activesupport (= 6.0.2.2)
+    activerecord (6.0.2.2)
+      activemodel (= 6.0.2.2)
+      activesupport (= 6.0.2.2)
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
     coderay (1.1.2)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     dotenv (2.7.5)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     method_source (0.9.2)
+    minitest (5.14.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
+    pg (1.2.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -21,6 +37,7 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
+    rake (13.0.1)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -50,19 +67,29 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    sinatra-activerecord (2.0.18)
+      activerecord (>= 4.1)
+      sinatra (>= 1.0)
+    thread_safe (0.3.6)
     tilt (2.0.10)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   dotenv (~> 2.7.5)
+  pg (~> 1.2.3)
   pry (~> 0.12.2)
   rack-test (~> 1.1.0)
+  rake (~> 13.0.1)
   rspec (~> 3.9.0)
   rubocop (~> 0.82.0)
   sinatra (~> 2.0.8.1)
+  sinatra-activerecord (~> 2.0.18)
 
 RUBY VERSION
    ruby 2.7.0p0

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Example: postgres://postgres:root@localhost:5432
 
 NOTE: **Do not** write a database name on the url, the file `config/database.yml` will create the database with the right name.
 
+
+### Database Setup
+
+To create and setup both development and test databases, run:
+
+```
+rake db:create db:migrate
+```
+
+NOTE: Make sure the `DATABASE_URL` is set correctly.
+
 ## Running the app
 
 Just run:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ We use [Rubocop](https://github.com/rubocop-hq/rubocop) as a linter. To check yo
 rubocop
 ```
 
-
 ### Debugging
 
 When you need to debug something, use [pry](https://github.com/pry/pry) as the following example:
@@ -44,4 +43,18 @@ class Foo
     binding.pry #code will stop here
   end
 end
+```
+
+### Tests
+
+We use [RSpec](https://github.com/rspec/rspec) as a test framework. To run all tests, run the following command:
+```
+rspec
+```
+
+If you want to run a single file, or a group of files, you can specify a path:
+
+```
+rspec spec/requests
+rspec spec/requests/base_spec.rb
 ```

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ Just run:
 ```
 ruby ./app.rb
 ```
+
+## Code Maintenance
+
+### Code styles
+
+We use [Rubocop](https://github.com/rubocop-hq/rubocop) as a linter. To check your code, run:
+
+```
+rubocop
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,21 @@ Using [Bundler](bundler.io) (should be installed if you are using RVM), run:
 bundler install
 ```
 
-After that, you should be able to run the app.
+### Environment variables
+
+For that, we have a `.env.sample` file. To create a local file, create a `.env` file with:
+```
+cp .env.sample .env
+```
+You can fill each variable with the following:
+
+#### `DATABASE_URL`
+Url to connect with database.
+
+Template: postgres://user:password@host:port
+Example: postgres://postgres:root@localhost:5432
+
+NOTE: **Do not** write a database name on the url, the file `config/database.yml` will create the database with the right name.
 
 ## Running the app
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ We use [Rubocop](https://github.com/rubocop-hq/rubocop) as a linter. To check yo
 ```
 rubocop
 ```
+
+
+### Debugging
+
+When you need to debug something, use [pry](https://github.com/pry/pry) as the following example:
+
+```ruby
+class Foo
+  def bar
+    puts 'I need to debug the next line'
+    binding.pry #code will stop here
+  end
+end
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'sinatra/activerecord'
+require 'sinatra/activerecord/rake'
+require './app'

--- a/app.rb
+++ b/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'sinatra'
 
 get '/' do

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sinatra'
+require 'dotenv/load'
 
 get '/' do
   'Hello world!'

--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,9 @@
 
 require 'sinatra'
 require 'dotenv/load'
+require 'sinatra/activerecord'
+
+set :database_file, './config/database.yml'
 
 get '/' do
   'Hello world!'

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,16 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  url: <%= ENV['DATABASE_URL'] %>
+
+development:
+  <<: *default
+  database: feedback_plataform_development
+
+test:
+  <<: *default
+  database: feedback_plataform_test
+
+production:
+  <<: *default

--- a/spec/requests/base_spec.rb
+++ b/spec/requests/base_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe '/' do
+  context 'GET to /' do
+    let(:subjet) { get '/' }
+
+    it 'returns status 200' do
+      expect(subjet.status).to eq 200
+    end
+
+    it 'displays a friendly message' do
+      expect(subjet.body).to include 'Hello world!'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,19 +2,12 @@
 
 ENV['APP_ENV'] = 'test'
 
-require 'rack/test'
 require_relative '../app.rb'
 
-module RSpecMixin
-  include ::Rack::Test::Methods
-
-  def app
-    Sinatra::Application
-  end
-end
+Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f } # rubocop:disable Lint/NonDeterministicRequireOrder
 
 RSpec.configure do |config|
-  config.include RSpecMixin
+  config.include SinatraRSpecMixin
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+ENV['APP_ENV'] = 'test'
+
+require 'rack/test'
+require_relative '../app.rb'
+
+module RSpecMixin
+  include ::Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+end
+
+RSpec.configure do |config|
+  config.include RSpecMixin
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
+  config.disable_monkey_patching!
+
+  config.warnings = true
+
+  if config.files_to_run.one? # rubocop:disable Style/IfUnlessModifier
+    config.default_formatter = 'doc'
+  end
+
+  config.profile_examples = 5
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'database_cleaner'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end

--- a/spec/support/sinatra_rspec_mixin.rb
+++ b/spec/support/sinatra_rspec_mixin.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rack/test'
+
+module SinatraRSpecMixin
+  include ::Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+end


### PR DESCRIPTION
## Motivação

Para começar o projeto, é necessário que algumas gems estejam no projeto

## Changelog
As seguintes gems foram adicionadas:

- sinatra-activerecord: para gerenciar coisas relacionadas ao banco de dados
- dotenv: para importar variáveis de ambiente a partir de um arquivo local
- pry: para debugging
- rubocop: para fazer análise de código 
- database_cleaner-active_record: para limpar o banco de dados entre testes
- rspec: framework de testes

Outras gem são dependências para que alguma dessas gems funcionem