### PR TITLE
Fix circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,16 +33,12 @@ jobs:
           command: bundle exec rubocop
 
       - run:
-          name: Setup database
-          command: bundle exec rake db:create db:migrate
-
-      - run:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:5432 -timeout 1000m
 
       - run:
           name: Setup the database
-          command: bundle exec rake db:setup db:test:prepare
+          command: bundle exec rake db:create # db:migrate
 
       - run:
           name: Run the ruby tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - '.git/**/*'
+    - 'vendor/**/*'
 
 # Layout
 Layout/LineLength:


### PR DESCRIPTION
## Motivation

CircleCI build were not passing due wrong setup

## Changelog

- Removed duplicated `Setup database` on `.circleci/config.yml` and removed migration execution, so activerecord will not raise an exception ~because there are no migration yet~
- Add `vendor` to rubocop ignored folders, so circleci cache will not be analysed
