### PR TITLE
Add delivery company

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run:
           name: Setup the database
-          command: bundle exec rake db:create # db:migrate
+          command: bundle exec rake db:create:all db:test:prepare
 
       - run:
           name: Run the ruby tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   Exclude:
     - '.git/**/*'
     - 'vendor/**/*'
-
+    - 'db/schema.rb'
 # Layout
 Layout/LineLength:
   Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Style/RedundantBegin:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+# Metrics
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 # Style
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'sinatra-activerecord', '~> 2.0.18'
 
 group :development, :test do
   gem 'dotenv', '~> 2.7.5'
+  gem 'factory_bot', '~> 5.1.2'
   gem 'pry', '~> 0.12.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
       database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
     dotenv (2.7.5)
+    factory_bot (5.1.2)
+      activesupport (>= 4.2.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -87,6 +89,7 @@ PLATFORMS
 DEPENDENCIES
   database_cleaner-active_record (~> 1.8.0)
   dotenv (~> 2.7.5)
+  factory_bot (~> 5.1.2)
   pg (~> 1.2.3)
   pry (~> 0.12.2)
   rack-test (~> 1.1.0)

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,7 @@ require 'dotenv/load'
 require 'sinatra/activerecord'
 
 require_relative './app/controllers/delivery_companies_controller.rb'
+require_relative './app/exceptions/unprocessable_entity_error.rb'
 
 set :database_file, './config/database.yml'
 
@@ -16,4 +17,20 @@ get '/delivery_companies' do
   status 200
   content_type :json
   DeliveryCompaniesController.index.to_json
+end
+
+post '/delivery_companies' do
+  content_type :json
+
+  begin
+    status 201
+    DeliveryCompaniesController.create(raw_params).to_json
+  rescue UnprocessableEntityError => e
+    status 422
+    e.message
+  end
+end
+
+def raw_params
+  JSON.parse(request.body.read)
 end

--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,7 @@ require 'sinatra/activerecord'
 
 require_relative './app/controllers/delivery_companies_controller.rb'
 require_relative './app/exceptions/unprocessable_entity_error.rb'
+require_relative './app/exceptions/resource_not_found_error.rb'
 
 set :database_file, './config/database.yml'
 
@@ -24,13 +25,22 @@ post '/delivery_companies' do
 
   begin
     status 201
-    DeliveryCompaniesController.create(raw_params).to_json
+    DeliveryCompaniesController.create(parsed_request_body).to_json
   rescue UnprocessableEntityError => e
     status 422
     e.message
   end
 end
 
-def raw_params
+delete '/delivery_companies/:id' do
+  begin
+    status 204
+    DeliveryCompaniesController.delete(params['id'])
+  rescue ResourceNotFoundError
+    status 404
+  end
+end
+
+def parsed_request_body
   JSON.parse(request.body.read)
 end

--- a/app.rb
+++ b/app.rb
@@ -4,8 +4,16 @@ require 'sinatra'
 require 'dotenv/load'
 require 'sinatra/activerecord'
 
+require_relative './app/controllers/delivery_companies_controller.rb'
+
 set :database_file, './config/database.yml'
 
 get '/' do
   'Hello world!'
+end
+
+get '/delivery_companies' do
+  status 200
+  content_type :json
+  DeliveryCompaniesController.index.to_json
 end

--- a/app/controllers/delivery_companies_controller.rb
+++ b/app/controllers/delivery_companies_controller.rb
@@ -3,6 +3,7 @@
 require_relative '../models/delivery_company.rb'
 require_relative '../decorators/delivery_company_decorator.rb'
 require_relative '../exceptions/unprocessable_entity_error.rb'
+require_relative '../exceptions/resource_not_found_error.rb'
 
 class DeliveryCompaniesController
   def self.index
@@ -19,6 +20,13 @@ class DeliveryCompaniesController
 
     delivery_company.save
     DeliveryCompanyDecorator.call(delivery_company)
+  end
+
+  def self.delete(id)
+    delivery_company = DeliveryCompany.find_by(id: id)
+    raise ResourceNotFoundError unless delivery_company
+
+    delivery_company.destroy
   end
 
   def self.creation_params(params)

--- a/app/controllers/delivery_companies_controller.rb
+++ b/app/controllers/delivery_companies_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../models/delivery_company.rb'
+require_relative '../decorators/delivery_company_decorator.rb'
+
+class DeliveryCompaniesController
+  def self.index
+    DeliveryCompany.all.map do |delivery_company|
+      DeliveryCompanyDecorator.call(delivery_company)
+    end
+  end
+end

--- a/app/controllers/delivery_companies_controller.rb
+++ b/app/controllers/delivery_companies_controller.rb
@@ -2,6 +2,7 @@
 
 require_relative '../models/delivery_company.rb'
 require_relative '../decorators/delivery_company_decorator.rb'
+require_relative '../exceptions/unprocessable_entity_error.rb'
 
 class DeliveryCompaniesController
   def self.index
@@ -9,4 +10,20 @@ class DeliveryCompaniesController
       DeliveryCompanyDecorator.call(delivery_company)
     end
   end
+
+  def self.create(raw_params)
+    sanitized_params = creation_params(raw_params)
+    delivery_company = DeliveryCompany.new(sanitized_params)
+
+    raise UnprocessableEntityError, delivery_company.errors.to_json unless delivery_company.valid?
+
+    delivery_company.save
+    DeliveryCompanyDecorator.call(delivery_company)
+  end
+
+  def self.creation_params(params)
+    { name: params['name'] }
+  end
+
+  private_class_method :creation_params
 end

--- a/app/decorators/delivery_company_decorator.rb
+++ b/app/decorators/delivery_company_decorator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DeliveryCompanyDecorator
+  def self.call(delivery_company)
+    {
+      id: delivery_company.id,
+      name: delivery_company.name
+    }
+  end
+end

--- a/app/exceptions/resource_not_found_error.rb
+++ b/app/exceptions/resource_not_found_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ResourceNotFoundError < StandardError
+end

--- a/app/exceptions/unprocessable_entity_error.rb
+++ b/app/exceptions/unprocessable_entity_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UnprocessableEntityError < StandardError
+end

--- a/app/models/delivery_company.rb
+++ b/app/models/delivery_company.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DeliveryCompany < ActiveRecord::Base
+  validates :name, presence: true, uniqueness: true
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,11 +6,11 @@ default: &default
 
 development:
   <<: *default
-  database: feedback_plataform_development
+  database: delivery_tracking_development
 
 test:
   <<: *default
-  database: feedback_plataform_test
+  database: delivery_tracking_test
 
 production:
   <<: *default

--- a/db/migrate/20200421220908_create_delivery_companies.rb
+++ b/db/migrate/20200421220908_create_delivery_companies.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateDeliveryCompanies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :delivery_companies do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_04_21_220908) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "delivery_companies", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/spec/decorators/delivery_company_decorator_spec.rb
+++ b/spec/decorators/delivery_company_decorator_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../app/decorators/delivery_company_decorator'
+require_relative '../factories/delivery_company'
+
+RSpec.describe DeliveryCompanyDecorator do
+  context 'given a DeliveryCompany instance' do
+    let(:delivery_company) { build(:delivery_company) }
+
+    it 'decorates the model' do
+      expected_result = { id: delivery_company.id, name: delivery_company.name }
+      expect(described_class.call(delivery_company)).to eq expected_result
+    end
+  end
+end

--- a/spec/factories/delivery_company.rb
+++ b/spec/factories/delivery_company.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'factory_bot'
+
+FactoryBot.define do
+  factory :delivery_company do
+    sequence :name do |n|
+      "company #{n}"
+    end
+  end
+end

--- a/spec/models/delivery_company_spec.rb
+++ b/spec/models/delivery_company_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../app/models/delivery_company'
+require_relative '../factories/delivery_company'
+
+RSpec.describe DeliveryCompany do
+  context 'when the model is valid' do
+    let(:subjet) { build(:delivery_company) }
+
+    it 'is saved' do
+      expect(subjet.valid?).to eq true
+    end
+
+    it 'can be saved' do
+      expect(subjet.save).to eq true
+    end
+  end
+
+  context 'when the model is not valid' do
+    context 'because it has no name' do
+      let(:subjet) { build(:delivery_company, name: '') }
+
+      it 'cannot be saved' do
+        expect(subjet.valid?).to eq false
+      end
+    end
+
+    context 'because it has a name that is already used' do
+      let(:already_existing_record) { create(:delivery_company) }
+      let(:subjet) { build(:delivery_company, name: already_existing_record.name) }
+
+      it 'cannot be saved' do
+        expect(subjet.valid?).to eq false
+      end
+    end
+  end
+end

--- a/spec/requests/delivery_companies/create_spec.rb
+++ b/spec/requests/delivery_companies/create_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../../app/models/delivery_company.rb'
+
+RSpec.describe 'POST /delivery_companies' do
+  context 'given a POST request to /delivery_companies' do
+    let(:request) { post '/delivery_companies', request_body.to_json }
+
+    context 'when the request body is valid' do
+      let(:request_body) { { name: 'company name' } }
+
+      context 'and there is no delivery company with that name' do
+        let(:parsed_response) { JSON.parse(request.body) }
+        let!(:delivery_companies_count_before_request) { DeliveryCompany.count }
+
+        it 'returns status 201' do
+          expect(request.status).to eq 201
+        end
+
+        it 'returns the created entity data' do
+          expect(parsed_response).to include 'id'
+          expect(parsed_response).to include 'name'
+          expect(parsed_response['name']).to eq request_body[:name]
+        end
+
+        it 'saves the entity on the database' do
+          request
+          expect(DeliveryCompany.count).to eq delivery_companies_count_before_request + 1
+        end
+      end
+
+      context 'and there is a delivery company with that name' do
+        let!(:delivery_company) { create(:delivery_company, name: request_body[:name]) }
+        let!(:delivery_companies_count_before_request) { DeliveryCompany.count }
+        let(:parsed_response) { JSON.parse(request.body) }
+
+        it 'returns status 422' do
+          expect(request.status).to eq 422
+        end
+
+        it 'returns the errors' do
+          expect(parsed_response).to include 'name'
+        end
+
+        it 'does not save the entity on the database' do
+          request
+          expect(DeliveryCompany.count).to eq delivery_companies_count_before_request
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/delivery_companies/delete_spec.rb
+++ b/spec/requests/delivery_companies/delete_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../../app/models/delivery_company.rb'
+
+RSpec.describe 'DELETE /delivery_companies/:id' do
+  context 'given a DELETE request to /delivery_companies/:id' do
+    let(:request) { delete "/delivery_companies/#{delivery_company.id}" }
+
+    context 'when the entity exists' do
+      let!(:delivery_company) { create(:delivery_company) }
+
+      it 'returns status 204' do
+        expect(request.status).to eq 204
+      end
+
+      it 'deletes the entity on the database' do
+        delivery_companies_count_before_request = DeliveryCompany.count
+        request
+        expect(DeliveryCompany.count).to eq delivery_companies_count_before_request - 1
+      end
+    end
+
+    context 'when the entity does not exist' do
+      let(:delivery_company) { OpenStruct.new(id: 123) }
+
+      it 'returns status 404' do
+        expect(request.status).to eq 404
+      end
+
+      it 'deletes nothing from database' do
+        delivery_companies_count_before_request = DeliveryCompany.count
+        request
+        expect(DeliveryCompany.count).to eq delivery_companies_count_before_request
+      end
+    end
+  end
+end

--- a/spec/requests/delivery_companies/index_spec.rb
+++ b/spec/requests/delivery_companies/index_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe '/delivery_companies' do
+RSpec.describe 'GET /delivery_companies' do
   context 'given a GET request to /delivery_companies' do
     let(:subjet) { get '/delivery_companies' }
 

--- a/spec/requests/delivery_companies/index_spec.rb
+++ b/spec/requests/delivery_companies/index_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe '/delivery_companies' do
+  context 'given a GET request to /delivery_companies' do
+    let(:subjet) { get '/delivery_companies' }
+
+    context 'when there are delivery companies' do
+      let!(:delivery_company) { create(:delivery_company) }
+      let(:parsed_response) { JSON.parse(subjet.body) }
+
+      it 'returns status 200' do
+        expect(subjet.status).to eq 200
+      end
+
+      it 'returns an array with all delivery companies' do
+        expect(parsed_response.length).to eq 1
+      end
+
+      it 'returns an array the delivery companies main attributes' do
+        expect(parsed_response[0]).to include 'id'
+        expect(parsed_response[0]).to include 'name'
+
+        expect(parsed_response.dig(0, 'id')).to eq delivery_company.id
+        expect(parsed_response.dig(0, 'name')).to eq delivery_company.name
+      end
+    end
+
+    context 'when there are no delivery companies' do
+      let(:parsed_response) { JSON.parse(subjet.body) }
+
+      it 'returns status 200' do
+        expect(subjet.status).to eq 200
+      end
+
+      it 'returns an empty array ' do
+        expect(parsed_response.length).to eq 0
+      end
+    end
+  end
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'factory_bot'
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
## Motivation

We need delivery companies to track packages from them. This PR adds endpoints to list, create and delete those companies
I did not create both show and edit endpoints because I think those are unnecessary to this kind of entity

## Changelog

- Readded migrations running on circleci
- Created DeliveryCompany entity and index, creation and deletion endpoints for them
- Added [factory bot gem](https://github.com/thoughtbot/factory_bot/) to easily create entities on tests
