### PR TITLE
Add base/example structure to AWS infra using terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ spec/examples.txt
 
 # Ignores local environment variables
 .env
+
+# Terraform
+terraform/.terraform
+terraform/*.tfplan
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - '.git/**/*'
     - 'vendor/**/*'
+    - 'terraform/**/*'
     - 'db/schema.rb'
 # Layout
 Layout/LineLength:

--- a/README.md
+++ b/README.md
@@ -83,3 +83,9 @@ If you want to run a single file, or a group of files, you can specify a path:
 rspec spec/requests
 rspec spec/requests/base_spec.rb
 ```
+
+## Infrastructure
+
+To maintain our infra, we use [Terraform](https://terraform.io). All files related to that, can be found on [terraform](terraform/) directory.
+
+For running **any** terraform commands, you should have two environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. We recommend using [aws-vault](https://github.com/99designs/aws-vault) to manage your AWS credentials

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region = "us-east-2"
+  version = "~> 2.60"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+# SNS
+output "example_topic_arn" {
+  value = aws_sns_topic.example_topic.arn
+}
+
+# SQS
+output "example_queue_arn" {
+  value = aws_sqs_queue.example_queue.arn
+}

--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "example_topic" {
+  name = var.sns_topic_name_example
+}

--- a/terraform/sns_sqs_subscription.tf
+++ b/terraform/sns_sqs_subscription.tf
@@ -1,0 +1,6 @@
+resource "aws_sns_topic_subscription" "sns_topic_subscription_example" {
+  endpoint             = aws_sqs_queue.example_queue.arn
+  protocol             = "sqs"
+  raw_message_delivery = true
+  topic_arn            = aws_sns_topic.example_topic.arn
+}

--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,0 +1,13 @@
+resource "aws_sqs_queue" "example_queue" {
+  fifo_queue     = "false"
+  name           = var.sqs_queue_name_example
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.example_queue_deadletter.arn
+    maxReceiveCount     = 4
+  })
+}
+
+resource "aws_sqs_queue" "example_queue_deadletter" {
+  fifo_queue = "false"
+  name       = var.sqs_queue_name_example_deadletter
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,6 @@
+# SNS
+sns_topic_name_example="example-topic"
+
+# SQS
+sqs_queue_name_example="example-queue"
+sqs_queue_name_example_deadletter="example-queue-deadletter"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,17 @@
+# SNS
+
+variable "sns_topic_name_example" {
+  description = "The name of the example sns topic"
+  type        = string
+}
+
+# SQS
+variable "sqs_queue_name_example" {
+  description = "The name of the example sqs queue"
+  type        = string
+}
+
+variable "sqs_queue_name_example_deadletter" {
+  description = "The name of the example sqs queue deadletter"
+  type        = string
+}


### PR DESCRIPTION
## Motivation

To notify user and start getting packages status, we should use something like a queue to process those things asynchronously. With that in mind, terraform should be a good tool to work with, since you can maintain all the infra with code

## Changelog

- Changed README to include terraform
- Created base aws config infra with terraform
- Created some example SNS-SQS example for future use (**that structure should not be used on production**, it's for and example only)