### PR TITLE
Create NotificationResquestStatus

### DIFF
--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
+require_relative './notification_request_status'
+
 class NotificationRequest < ActiveRecord::Base
   validates :tracking_code, presence: true
   validates :email_for_contact, presence: true
 
   belongs_to :delivery_company, optional: false
+
+  has_many :statuses,
+           -> { order('created_at') },
+           dependent: :destroy,
+           class_name: 'NotificationRequestStatus'
 end

--- a/app/models/notification_request_status.rb
+++ b/app/models/notification_request_status.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NotificationRequestStatus < ActiveRecord::Base
+  validates :content, presence: true
+
+  belongs_to :notification_request, optional: false
+end

--- a/db/migrate/20200608022017_create_notification_request_status.rb
+++ b/db/migrate/20200608022017_create_notification_request_status.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateNotificationRequestStatus < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notification_request_statuses do |t|
+      t.text :content
+      t.references :notification_request
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_145834) do
+ActiveRecord::Schema.define(version: 2020_06_08_022017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 2020_04_25_145834) do
     t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "notification_request_statuses", force: :cascade do |t|
+    t.text "content"
+    t.bigint "notification_request_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notification_request_id"], name: "index_notification_request_statuses_on_notification_request_id"
   end
 
   create_table "notification_requests", force: :cascade do |t|

--- a/spec/factories/notification_request_status.rb
+++ b/spec/factories/notification_request_status.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'factory_bot'
+require_relative './notification_request'
+
+FactoryBot.define do
+  factory :notification_request_status do
+    content { 'content' }
+
+    association :notification_request, strategy: :create
+  end
+end

--- a/spec/models/notification_request_spec.rb
+++ b/spec/models/notification_request_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe NotificationRequest do
       end
     end
   end
+
+  context 'when it has statuses' do
+    let(:subject) { create(:notification_request) }
+
+    before(:each) do
+      create_list(:notification_request_status, 2, notification_request: subject)
+    end
+
+    it 'they are ordered by #created_at' do
+      expect(subject.statuses.last.created_at).to be >= subject.statuses.first.created_at
+    end
+  end
 end

--- a/spec/models/notification_request_status_spec.rb
+++ b/spec/models/notification_request_status_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../../app/models/notification_request_status'
+require_relative '../factories/notification_request_status'
+
+RSpec.describe NotificationRequestStatus do
+  context 'when the model is valid' do
+    let(:subject) { build(:notification_request_status) }
+
+    it 'is saved' do
+      expect(subject.valid?).to eq true
+    end
+
+    it 'can be saved' do
+      expect(subject.save).to eq true
+    end
+  end
+
+  context 'when the model is not valid' do
+    context 'because it has no content' do
+      let(:subject) { build(:notification_request_status, content: '') }
+
+      it 'cannot be saved' do
+        expect(subject.valid?).to eq false
+      end
+    end
+
+    context 'because it has no notification request' do
+      let(:subject) { build(:notification_request_status, notification_request: nil) }
+
+      it 'cannot be saved' do
+        expect(subject.valid?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation
To track NotificationRequest updates, we need something to persist its current state.
Thats what NotificationResquestStatus represents, an snapshot of a NotificationResquest state

## Changelog

- Created `NotificationResquestStatust` (model, migration, factory and spec)