### PR TITLE
Add endpoitnt to create NotificationRequestStatus

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -60,6 +60,24 @@ post '/notification_requests' do
   end
 end
 
+post '/notification_requests/:id/status' do
+  controller_params = {
+    'notification_request_id' => params['id'],
+    'content' => parsed_request_body['content']
+  }
+
+  begin
+    status 201
+    NotificationRequestController
+      .new(params: controller_params)
+      .update_status
+  rescue UnprocessableEntityError => e
+    content_type :json
+    status 422
+    e.message
+  end
+end
+
 def parsed_request_body
   JSON.parse(request.body.read)
 end

--- a/app/controllers/notification_requests_controller.rb
+++ b/app/controllers/notification_requests_controller.rb
@@ -28,6 +28,15 @@ class NotificationRequestController
     decorated_entity
   end
 
+  def update_status
+    notification_request_status = NotificationRequestStatus.new(update_status_params)
+    unless notification_request_status.valid?
+      raise UnprocessableEntityError, notification_request_status.errors.to_json
+    end
+
+    notification_request_status.save
+  end
+
   private
 
   def creation_params
@@ -35,6 +44,13 @@ class NotificationRequestController
       tracking_code: @params['tracking_code'],
       email_for_contact: @params['email_for_contact'],
       delivery_company_id: @params['delivery_company_id']
+    }
+  end
+
+  def update_status_params
+    @update_status_params ||= {
+      notification_request_id: @params['notification_request_id'],
+      content: @params['content']
     }
   end
 end

--- a/infra/lambdas/update_notification_request/Makefile
+++ b/infra/lambdas/update_notification_request/Makefile
@@ -7,5 +7,7 @@ create-zip-file:
 # Commands that start with underscore are run *inside* the container.
 
 _install:
+	bundle config --local set clean true
+	bundle config --local set path 'vendor/bundle'
 	bundle config --local silence_root_warning true
-	bundle install --path vendor/bundle --clean
+	bundle install

--- a/infra/lambdas/update_notification_request/lambda_function.rb
+++ b/infra/lambdas/update_notification_request/lambda_function.rb
@@ -30,7 +30,7 @@ def send_status_to_backend(status, destiny_url, notification_request_id)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
   request = Net::HTTP::Post.new(uri.request_uri)
-  request.body = status
+  request.body = { content: status }.to_json
   http.request(request)
 end
 

--- a/spec/requests/notification_requests/create_status_spec.rb
+++ b/spec/requests/notification_requests/create_status_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative '../../factories/notification_request.rb'
+require_relative '../../../app/models/notification_request.rb'
+
+RSpec.describe 'POST /notification_requests/:id/status' do
+  context 'given a POST request to /notification_requests/:id/status' do
+    let(:request) do
+      post "/notification_requests/#{notification_request_id}/status",
+           request_body.to_json
+    end
+
+    context 'when the id on the url is valid' do
+      let(:notification_request) { create(:notification_request) }
+      let(:notification_request_id) { notification_request.id }
+
+      context 'and the request body is valid' do
+        let(:request_body) { { content: 'new status' } }
+
+        it 'returns status 201' do
+          expect(request.status).to eq(201)
+        end
+
+        it 'saves the entity on the database' do
+          notification_request_statuses_count = notification_request.statuses.length
+          request
+          expect(
+            notification_request.reload.statuses.length
+          ).to eq(notification_request_statuses_count + 1)
+        end
+      end
+
+      context 'and the request body is invalid' do
+        let(:parsed_response) { JSON.parse(request.body) }
+
+        context 'because there is no content' do
+          let(:request_body) { { content: nil } }
+
+          it 'returns status 422' do
+            expect(request.status).to eq(422)
+          end
+
+          it 'returns the errors' do
+            expect(parsed_response).to include 'content'
+          end
+        end
+      end
+    end
+
+    context 'when the id on the url is not valid' do
+      let(:notification_request_id) { '123' }
+      let(:request_body) { { content: 'new status' } }
+      let(:parsed_response) { JSON.parse(request.body) }
+
+      it 'returns status 422' do
+        expect(request.status).to eq(422)
+      end
+
+      it 'returns the errors' do
+        expect(parsed_response).to include 'notification_request'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

We need an endpoint to create a `NotificationRequestStatus`

## Changelog

- Create an endpoint (`POST /notification_request/:id/status`) to create `NotificationRequestStatus`'s
- Changed `update_notification_request` lambda function, to have a json body, instead of a plain text string
