### PR TITLE
Add i18n

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@
 
 require 'sinatra'
 require 'dotenv/load' unless production?
+require 'i18n'
 require 'sinatra/activerecord'
 
 require_relative './app/controllers/delivery_companies_controller.rb'
@@ -12,6 +13,10 @@ require_relative './app/exceptions/resource_not_found_error.rb'
 
 set :database_file, './config/database.yml'
 set :views, settings.root + '/app/views'
+
+I18n.load_path << Dir[File.expand_path('config/locales') + '/*.yml']
+I18n.config.enforce_available_locales = false
+I18n.default_locale = 'pt-BR'
 
 FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded'
 JSON_CONTENT_TYPE = 'application/json'

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Notificador de Entregas</title>
+  <title><%= I18n.t(:delivery_tracking) %></title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
 </head>

--- a/app/views/notification_requests/create.erb
+++ b/app/views/notification_requests/create.erb
@@ -1,13 +1,22 @@
 <div class="container">
   <div class="content">
     <%= erb :logo %>
-    <h1>Notificador de Entregas</h1>
+    <h1><%= I18n.t(:delivery_tracking) %></h1>
 
     <form action="/notification_requests" method="POST">
-      <input type="text" placeholder="Código de Rastreio" class="field" name="tracking_code"><br />
+      <input
+        type="text"
+        placeholder="<%= NotificationRequest.human_attribute_name('tracking_code') %>"
+        class="field"
+        name="tracking_code"
+      ><br />
       <span class="field-error"> <%= show_errors_for_field(form_errors, 'tracking_code') %> </span>
 
-      <input placeholder="Email para contato" class="field" name="email_for_contact"><br />
+      <input
+        placeholder="<%= NotificationRequest.human_attribute_name('email_for_contact') %>"
+        class="field"
+        name="email_for_contact"
+      ><br />
       <span class="field-error"> <%= show_errors_for_field(form_errors, 'email_for_contact') %> </span>
 
       <select class="field" name="delivery_company_id">
@@ -15,7 +24,7 @@
           <%= "<option value=\"#{company[:id]}\">#{company[:name]}</option>" %>
         <% end %>
       </select>
-      <input type="submit" value="Notifique-me!" class="btn">
+      <input type="submit" value="<%= I18n.t('views.notify_me') %>" class="btn">
     </form>
   </div>
 </div>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,29 @@
+pt-BR:
+  delivery_tracking: Notificador de Entregas
+
+  activerecord:
+    attributes:
+      notification_request:
+        tracking_code: Código de rastreio
+        email_for_contact: Email para contato
+    errors:
+      messages:
+        blank: nao pode ficar em branco
+      models:
+        notification_request:
+          attributes:
+            email_for_contact:
+              invalid: formato de email invalido
+
+  views:
+    notify_me: Notifique-me!
+
+
+  email:
+    new_notification_request:
+      subject: Recebemos a sua solicitação
+      body: "A notificação para o código de rastreio %{tracking_code} foi criada com sucesso!"
+
+    update_on_notification_request:
+      subject: Houve uma atualização no seu pedido
+      body: "O pedido com o código de rastreio %{tracking_code} sofreu uma atualização"

--- a/infra/email/new_notification_request_email_sender.rb
+++ b/infra/email/new_notification_request_email_sender.rb
@@ -2,7 +2,6 @@
 
 require 'sendgrid-ruby'
 
-# TODO: Use i18n on email content
 class NewNotificationRequestEmailSender
   def initialize(to:, tracking_code:)
     @to = to
@@ -30,13 +29,13 @@ class NewNotificationRequestEmailSender
   end
 
   def subject
-    'Recebemos a sua solicitação'
+    I18n.t('email.new_notification_request.subject')
   end
 
   def content
     SendGrid::Content.new(
       type: 'text/plain',
-      value: "A notificação para o código de rastreio \"#{@tracking_code}\" foi criada com sucesso!"
+      value: I18n.t('email.new_notification_request.body', tracking_code: @tracking_code)
     )
   end
 end

--- a/infra/email/update_on_notification_request_email_sender.rb
+++ b/infra/email/update_on_notification_request_email_sender.rb
@@ -2,7 +2,6 @@
 
 require 'sendgrid-ruby'
 
-# TODO: Use i18n on email content
 class UpdateOnNotificationRequestEmailSender
   def initialize(to:, tracking_code:)
     @to = to
@@ -30,13 +29,13 @@ class UpdateOnNotificationRequestEmailSender
   end
 
   def subject
-    'Houve uma atualização no seu pedido'
+    I18n.t('email.update_on_notification_request.subject')
   end
 
   def content
     SendGrid::Content.new(
       type: 'text/plain',
-      value: "O pedido com o código de rastreio \"#{@tracking_code}\" sofreu uma atualização"
+      value: I18n.t('email.update_on_notification_request.body', tracking_code: @tracking_code)
     )
   end
 end


### PR DESCRIPTION
## Motivation

As we may need support from multiple locations, this PR adds i18n support

## Changelog

Added `config/locales` directory, with a default locale set to `pt-BR`
Changed every hardcoded text, that is shown to the user, to a translated text