### PR TITLE
Add flash messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rake', '~> 13.0.1'
 gem 'sendgrid-ruby', '~> 6.3.1'
 gem 'sinatra', '~> 2.0.8.1'
 gem 'sinatra-activerecord', '~> 2.0.18'
+gem 'sinatra-flash', '~> 0.3.0'
 
 group :development, :test do
   gem 'dotenv', '~> 2.7.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     sinatra-activerecord (2.0.18)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
+    sinatra-flash (0.3.0)
+      sinatra (>= 1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.7)
@@ -116,6 +118,7 @@ DEPENDENCIES
   sendgrid-ruby (~> 6.3.1)
   sinatra (~> 2.0.8.1)
   sinatra-activerecord (~> 2.0.18)
+  sinatra-flash (~> 0.3.0)
 
 RUBY VERSION
    ruby 2.7.0p0

--- a/app/views/notification_requests/create.erb
+++ b/app/views/notification_requests/create.erb
@@ -3,6 +3,12 @@
     <%= erb :logo %>
     <h1><%= I18n.t(:delivery_tracking) %></h1>
 
+    <% if flash[:success] %>
+      <div class="flash-success">
+        <span><%= I18n.t('views.notification_request.create.success') %></span>
+      </div>
+    <% end %>
+
     <form action="/notification_requests" method="POST">
       <input
         type="text"
@@ -24,7 +30,7 @@
           <%= "<option value=\"#{company[:id]}\">#{company[:name]}</option>" %>
         <% end %>
       </select>
-      <input type="submit" value="<%= I18n.t('views.notify_me') %>" class="btn">
+      <input type="submit" value="<%= I18n.t('views.notification_request.create.notify_me') %>" class="btn">
     </form>
   </div>
 </div>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -8,16 +8,18 @@ pt-BR:
         email_for_contact: Email para contato
     errors:
       messages:
-        blank: nao pode ficar em branco
+        blank: Não pode ficar em branco
       models:
         notification_request:
           attributes:
             email_for_contact:
-              invalid: formato de email invalido
+              invalid: Formato de email inválido
 
   views:
-    notify_me: Notifique-me!
-
+    notification_request:
+      create:
+        notify_me: Notifique-me!
+        success: Solicitação criada com sucesso
 
   email:
     new_notification_request:

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -123,6 +123,18 @@ form .btn:active {
   z-index: 1;
 }
 span.field-error {
-  font-family: "Open Sans", sans-serif;
   color: #f00;
+}
+.flash-success {
+  background-color: #63ab61;
+  border-radius: 3px;
+  color: #fff;
+  width: 90%;
+  font-size: 16px;
+  margin-bottom: 10px;
+  margin-left: 5%;
+  padding: 6px 0;
+  height: 40px;
+  padding-left: 6px;
+  text-align: left;
 }


### PR DESCRIPTION
## Motivation

To show success and failure messages, a good approach is using sessions, so nothing need to be passed through the url

## Changelog

- Add [sinatra-flash](https://github.com/SFEley/sinatra-flash) gem
- Add success message on form submission
- Form errors are, now, passed with a flash message
