### PR TITLE
Delete inactive notification requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -66,6 +66,11 @@ post '/reminders/update_notification_requests' do
   RemindersController.new.update_notification_requests
 end
 
+post '/reminders/close_inactive_notification_requests' do
+  status 204
+  RemindersController.new.close_inactive_notification_requests
+end
+
 post '/notification_requests' do
   pass unless request.content_type == JSON_CONTENT_TYPE
   content_type :json

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -2,13 +2,16 @@
 
 require_relative '../models/notification_request.rb'
 require_relative '../decorators/notification_request_decorator.rb'
+require_relative '../helpers/notification_request_finisher.rb'
 require_relative '../../infra/sns/notification_request_update_publisher'
 
 class RemindersController
   def initialize(
-    update_notificatier: NotificationRequestUpdatePublisher.new
+    update_notificatier: NotificationRequestUpdatePublisher.new,
+    notification_request_finisher: NotificationRequestFinisher.new
   )
     @update_notificatier = update_notificatier
+    @notification_request_finisher = notification_request_finisher
   end
 
   def update_notification_requests
@@ -16,6 +19,12 @@ class RemindersController
       @update_notificatier.publish(
         NotificationRequestDecorator.new(notification_request).with_delivery_company
       )
+    end
+  end
+
+  def close_inactive_notification_requests
+    NotificationRequest.inactive.each do |notification_request|
+      @notification_request_finisher.finish(notification_request)
     end
   end
 end

--- a/app/helpers/notification_request_finisher.rb
+++ b/app/helpers/notification_request_finisher.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../infra/email/finish_notification_request_email_sender.rb'
+
+class NotificationRequestFinisher
+  def initialize(
+    finisher_email_sender_class: FinishNotificationRequestEmailSender
+  )
+    @finisher_email_sender_class = finisher_email_sender_class
+  end
+
+  def finish(notification_request)
+    ActiveRecord::Base.transaction do
+      notification_request.status = NotificationRequest::STATUSES[:DONE]
+      notification_request.save!
+      @finisher_email_sender_class.new(
+        to: notification_request.email_for_contact,
+        tracking_code: notification_request.tracking_code
+      ).send
+    end
+  end
+end

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -52,3 +52,7 @@ pt-BR:
     update_on_notification_request:
       subject: Houve uma atualização no seu pedido
       body: "O pedido com o código de rastreio %{tracking_code} sofreu uma atualização"
+
+    finish_notification_request:
+      subject: O rastreio do seu pedido foi finalizado
+      body: "O seu pedido, com o código de rastreio %{tracking_code}, está há muito tempo sem uma atualização. A partir de agora, vamos considerá-lo como finalizado. Se quiser continuar recebendo notificações, vá ao nosso site e refaça a solicitação"

--- a/infra/email/finish_notification_request_email_sender.rb
+++ b/infra/email/finish_notification_request_email_sender.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'sendgrid-ruby'
+
+class FinishNotificationRequestEmailSender
+  def initialize(to:, tracking_code:)
+    @to = to
+    @tracking_code = tracking_code
+  end
+
+  def send
+    mail = SendGrid::Mail.new(from, subject, destiny, content)
+
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    response = sg.client.mail._('send').post(request_body: mail.to_json)
+    puts "[#{self.class}] sent email to #{@to}, \
+          using #{@tracking_code} as tracking code, \
+          and got the response: #{response}"
+  end
+
+  private
+
+  def from
+    SendGrid::Email.new(email: ENV['EMAIL_DEFAULT_SENDER'])
+  end
+
+  def destiny
+    SendGrid::Email.new(email: @to)
+  end
+
+  def subject
+    I18n.t('email.finish_notification_request.subject')
+  end
+
+  def content
+    SendGrid::Content.new(
+      type: 'text/plain',
+      value: I18n.t('email.finish_notification_request.body', tracking_code: @tracking_code)
+    )
+  end
+end

--- a/spec/helpers/notification_request_finisher_spec.rb
+++ b/spec/helpers/notification_request_finisher_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative '../../app/helpers/notification_request_finisher.rb'
+
+RSpec.describe NotificationRequestFinisher do
+  context 'when its needed to finish a NotificationRequest' do
+    let(:result) { described_class.new }
+    let(:notification_request) { double(NotificationRequest) }
+
+    context 'and there is no problem saving it after setting it to done' do
+      before(:each) do
+        allow(notification_request).to receive(:status=)
+        allow(notification_request).to receive(:save!)
+        allow(notification_request).to receive(:email_for_contact)
+        allow(notification_request).to receive(:tracking_code)
+      end
+
+      context 'and the email is sent sucesfully' do
+        before(:each) do
+          allow_any_instance_of(FinishNotificationRequestEmailSender).to receive(:send)
+        end
+
+        it 'sets the notification request as done' do
+          expect(notification_request)
+            .to receive(:status=)
+            .with(NotificationRequest::STATUSES[:DONE])
+            .exactly(1).time
+
+          subject.finish(notification_request)
+        end
+
+        it 'saves the notification request' do
+          expect(notification_request)
+            .to receive(:save!)
+            .exactly(1).time
+
+          subject.finish(notification_request)
+        end
+
+        it 'sends an email' do
+          expect_any_instance_of(FinishNotificationRequestEmailSender)
+            .to receive(:send)
+            .exactly(1).time
+
+          subject.finish(notification_request)
+        end
+      end
+
+      context 'and there is a problem sending the email' do
+        before(:each) do
+          allow_any_instance_of(FinishNotificationRequestEmailSender)
+            .to receive(:send)
+            .and_raise(StandardError.new('problem sending the email'))
+        end
+
+        it 'raises an error' do
+          expect do
+            subject.finish(notification_request)
+          end.to raise_error(StandardError, 'problem sending the email')
+        end
+      end
+    end
+
+    context 'and there is a problem saving it after setting it to done' do
+      before(:each) do
+        allow(notification_request).to receive(:status=)
+        allow(notification_request)
+          .to receive(:save!)
+          .and_raise(StandardError.new('problem on saving'))
+      end
+
+      it 'raises an error' do
+        expect do
+          subject.finish(notification_request)
+        end.to raise_error(StandardError, 'problem on saving')
+      end
+    end
+  end
+end

--- a/spec/helpers/notification_request_status_creator_spec.rb
+++ b/spec/helpers/notification_request_status_creator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe NotificationRequestStatusCreator do
             expect { result.create! }.to change { NotificationRequestStatus.count }.by(1)
           end
 
-          it 'save the NotificationRequestStatus ' do
+          it 'sends the email ' do
             expect_any_instance_of(UpdateOnNotificationRequestEmailSender)
               .to receive(:send).exactly(1).time
 

--- a/spec/models/notification_request_spec.rb
+++ b/spec/models/notification_request_spec.rb
@@ -69,4 +69,41 @@ RSpec.describe NotificationRequest do
       expect(subject.statuses.last.created_at).to be >= subject.statuses.first.created_at
     end
   end
+
+  context 'when it is active' do
+    before(:each) do
+      create_list(:notification_request, 2, status: NotificationRequest::STATUSES[:ACTIVE])
+      create_list(:notification_request, 2, status: NotificationRequest::STATUSES[:DONE])
+    end
+
+    it 'retrieves only the active ones' do
+      expect(NotificationRequest.active.count).to eq(2)
+    end
+  end
+
+  context 'when it is inactive' do
+    before(:each) do
+      create_list(
+        :notification_request, 2, status: NotificationRequest::STATUSES[:ACTIVE]
+      ).each do |nr|
+        create(
+          :notification_request_status, notification_request: nr, created_at: DateTime.now
+        )
+      end
+
+      create_list(
+        :notification_request, 2, status: NotificationRequest::STATUSES[:ACTIVE]
+      ).each do |nr|
+        create(
+          :notification_request_status,
+          notification_request: nr,
+          created_at: DateTime.now - NotificationRequest::DAYS_TO_BE_CONSIDERED_INACTIVE
+        )
+      end
+    end
+
+    it 'retrieves only the active ones' do
+      expect(NotificationRequest.inactive.count).to eq(2)
+    end
+  end
 end

--- a/spec/requests/reminders/close_inactive_notification_requests.rb
+++ b/spec/requests/reminders/close_inactive_notification_requests.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../../factories/notification_request.rb'
+require_relative '../../factories/notification_request_status.rb'
+require_relative '../../../app/models/notification_request.rb'
+require_relative '../../../app/helpers/notification_request_finisher.rb'
+
+RSpec.describe 'POST /reminders/update_notification_requests' do
+  context 'when receiving a request to remind to update notification requests' do
+    let(:request) { post '/reminders/close_inactive_notification_requests' }
+
+    context 'and there are inactive notification requests' do
+      before(:each) do
+        allow_any_instance_of(NotificationRequestFinisher).to receive(:finish)
+
+        nr = create(:notification_request, status: NotificationRequest::STATUSES[:ACTIVE])
+        create(
+          :notification_request_status,
+          notification_request: nr,
+          created_at: DateTime.now - NotificationRequest::DAYS_TO_BE_CONSIDERED_INACTIVE
+        )
+      end
+
+      it 'returns status 204' do
+        expect(request.status).to eq 204
+      end
+
+      it 'call the finisher for each inactive notification request' do
+        expect_any_instance_of(NotificationRequestFinisher)
+          .to receive(:finish).exactly(1).time
+
+        request
+      end
+    end
+
+    context 'and there are no inactive notification requests' do
+      before(:each) do
+        nr = create(:notification_request, status: NotificationRequest::STATUSES[:ACTIVE])
+        create(:notification_request_status, notification_request: nr)
+      end
+
+      it 'returns status 204' do
+        expect(request.status).to eq 204
+      end
+
+      it 'does not call the notifier' do
+        expect_any_instance_of(NotificationRequestFinisher)
+          .not_to receive(:finish)
+
+        request
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

To end a `NotificationRequest`'s life cycle, an endpoint to remind to check which `NotificationRequest`s are inactive (5 days without updates)

## Changelog

- Create the endpoint `POST /reminders/close_inactive_notification_requests`
  - For that, `NotificationRequestFinisher` will keep the responsibility to do all things to do that
  - A new email will be sent through `FinishNotificationRequestEmailSender`
