### PR TITLE
Lambda to remind to close inactive notification requests

### DIFF
--- a/infra/lambdas/remind_close_inactive_notification_requests/Dockerfile
+++ b/infra/lambdas/remind_close_inactive_notification_requests/Dockerfile
@@ -1,0 +1,5 @@
+FROM lambci/lambda:build-ruby2.7
+
+RUN gem update bundler
+
+CMD "/bin/bash"

--- a/infra/lambdas/remind_close_inactive_notification_requests/Gemfile
+++ b/infra/lambdas/remind_close_inactive_notification_requests/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'nokogiri', '~> 1.10.9'

--- a/infra/lambdas/remind_close_inactive_notification_requests/Gemfile.lock
+++ b/infra/lambdas/remind_close_inactive_notification_requests/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.10.9)
+
+BUNDLED WITH
+   2.1.4

--- a/infra/lambdas/remind_close_inactive_notification_requests/Makefile
+++ b/infra/lambdas/remind_close_inactive_notification_requests/Makefile
@@ -1,0 +1,11 @@
+create-zip-file:
+	docker build -t lambda-ruby2.7-nokogiri .
+	docker run --rm -it -v $$PWD:/var/task -w /var/task lambda-ruby2.7-nokogiri make _install
+	rm -f lambda.zip
+	zip -q -r lambda.zip .
+
+# Commands that start with underscore are run *inside* the container.
+
+_install:
+	bundle config --local silence_root_warning true
+	bundle install --path vendor/bundle --clean

--- a/infra/lambdas/remind_close_inactive_notification_requests/lambda_function.rb
+++ b/infra/lambdas/remind_close_inactive_notification_requests/lambda_function.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+load_paths = Dir['./vendor/bundle/ruby/*/gems/**/lib']
+$LOAD_PATH.unshift(*load_paths)
+
+require 'nokogiri'
+
+def lambda_handler(event:, context:)
+  uri = URI.parse("#{ENV['BACKEND_URL']}/reminders/close_inactive_notification_requests")
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  request = Net::HTTP::Post.new(uri.request_uri)
+  http.request(request)
+end

--- a/terraform/cloudwatch_event_rule.tf
+++ b/terraform/cloudwatch_event_rule.tf
@@ -1,5 +1,7 @@
-resource "aws_cloudwatch_event_rule" "every_one_hour" {
-    name = "every-one-hour"
-    description = "Fires every one hour"
-    schedule_expression = "rate(1 hour)"
+resource "aws_cloudwatch_event_rule" "every_one_hour_on_business_hours_on_weekdays" {
+    name = "every-one-hour-on-business-hours-on-weekdays"
+    description = "Fires every one hour on business hours on weekdays"
+
+    # this cron run in UTC, so BRT time will be 8-18
+    schedule_expression = "cron(0 11-21 ? * MON-FRI *)"
 }

--- a/terraform/cloudwatch_event_target.tf
+++ b/terraform/cloudwatch_event_target.tf
@@ -1,4 +1,9 @@
 resource "aws_cloudwatch_event_target" "update_notification_requests_every_hour" {
-    rule = aws_cloudwatch_event_rule.every_one_hour.name
+    rule = aws_cloudwatch_event_rule.every_one_hour_on_business_hours_on_weekdays.name
     arn = aws_lambda_function.remind_update_notification_requests.arn
+}
+
+resource "aws_cloudwatch_event_target" "close_inactive_notification_requests_every_hour" {
+    rule = aws_cloudwatch_event_rule.every_one_hour_on_business_hours_on_weekdays.name
+    arn = aws_lambda_function.remind_close_inactive_notification_requests.arn
 }

--- a/terraform/cloudwatch_log_group.tf
+++ b/terraform/cloudwatch_log_group.tf
@@ -7,3 +7,8 @@ resource "aws_cloudwatch_log_group" "lambda_remind_update_notification_requests"
   name              = "/aws/lambda/${aws_lambda_function.remind_update_notification_requests.function_name}"
   retention_in_days = var.cloudwatch_log_group_retention_in_days
 }
+
+resource "aws_cloudwatch_log_group" "lambda_remind_close_inactive_notification_requests" {
+  name              = "/aws/lambda/${aws_lambda_function.remind_close_inactive_notification_requests.function_name}"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -29,3 +29,18 @@ resource "aws_lambda_function" "remind_update_notification_requests" {
     }
   }
 }
+resource "aws_lambda_function" "remind_close_inactive_notification_requests" {
+  filename         = var.lambda_remind_close_inactive_notification_requests_filename
+  function_name    = "remind-close-inactive-notification-requests"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = var.lambda_remind_close_inactive_notification_requests_handler
+  runtime          = var.lambda_remind_close_inactive_notification_requests_runtime
+  timeout          = var.lambda_remind_close_inactive_notification_requests_timeout
+  source_code_hash = filebase64sha256(var.lambda_remind_close_inactive_notification_requests_filename)
+
+  environment {
+    variables = {
+      BACKEND_URL = var.lambda_backend_url
+    }
+  }
+}

--- a/terraform/lambda_permission.tf
+++ b/terraform/lambda_permission.tf
@@ -6,11 +6,18 @@ resource "aws_lambda_permission" "notification_request_update_permission" {
   source_arn    = aws_sns_topic.notification_request_update.arn
 }
 
-
 resource "aws_lambda_permission" "remind_update_notification_requests_permission" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.remind_update_notification_requests.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.every_one_hour.arn
+  source_arn    = aws_cloudwatch_event_rule.every_one_hour_on_business_hours_on_weekdays.arn
+}
+
+resource "aws_lambda_permission" "remind_close_inactive_notification_requests_permission" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.remind_close_inactive_notification_requests.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.every_one_hour_on_business_hours_on_weekdays.arn
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -9,6 +9,11 @@ lambda_remind_update_notification_requests_filename="../infra/lambdas/remind_upd
 lambda_remind_update_notification_requests_runtime="ruby2.7"
 lambda_remind_update_notification_requests_timeout="10"
 
+lambda_remind_close_inactive_notification_requests_handler="lambda_function.lambda_handler"
+lambda_remind_close_inactive_notification_requests_filename="../infra/lambdas/remind_close_inactive_notification_requests/lambda.zip"
+lambda_remind_close_inactive_notification_requests_runtime="ruby2.7"
+lambda_remind_close_inactive_notification_requests_timeout="60"
+
 lambda_backend_url="https://delivery-tracking.herokuapp.com"
 
 # SNS

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,27 @@ variable "lambda_remind_update_notification_requests_timeout" {
 }
 
 
+variable "lambda_remind_close_inactive_notification_requests_handler" {
+  description = "The handler of the lambda remind_close_inactive_notification_requests"
+  type        = string
+}
+
+variable "lambda_remind_close_inactive_notification_requests_filename" {
+  description = "The filename of the lambda remind_close_inactive_notification_requests"
+  type        = string
+}
+
+
+variable "lambda_remind_close_inactive_notification_requests_runtime" {
+  description = "The runtime language of the lambda remind_close_inactive_notification_requests"
+  type        = string
+}
+
+variable "lambda_remind_close_inactive_notification_requests_timeout" {
+  description = "The timeout, in seconds, of the lambda remind_close_inactive_notification_requests"
+  type        = string
+}
+
 variable "lambda_notification_request_update_handler" {
   description = "The handler of the lambda notification_request_update"
   type        = string
@@ -37,7 +58,6 @@ variable "lambda_notification_request_update_filename" {
   description = "The filename of the lambda notification_request_update"
   type        = string
 }
-
 
 variable "lambda_notification_request_update_runtime" {
   description = "The runtime language of the lambda notification_request_update"


### PR DESCRIPTION
## Motivation

Create a lambda to do a POST request to `reminders/close_inactive_notification_requests`

## Changelog

- Created lambda and AWS infra
- Changed `every_one_hour` cloudwatch trigger to `every_one_hour_on_business_hours_on_weekdays`. With this, lambdas will only run on weekdays within business hours ~because we are not that rich~