### PR TITLE
Fix NotificationRequest inactive scope

### DIFF
--- a/app/models/notification_request.rb
+++ b/app/models/notification_request.rb
@@ -26,15 +26,21 @@ class NotificationRequest < ActiveRecord::Base
 
   scope :active, -> { where(status: STATUSES[:ACTIVE]) }
   scope :inactive, lambda {
-    find_by_sql(["
-      SELECT *
-      FROM notification_requests
-      WHERE id IN(
-        SELECT distinct on (notification_request_id) notification_request_id
-        FROM notification_request_statuses
-        WHERE created_at <= ?
-        ORDER BY notification_request_id, created_at
-      )
-    ", DateTime.now - NotificationRequest::DAYS_TO_BE_CONSIDERED_INACTIVE])
+    find_by_sql(
+      [
+        "
+          SELECT *
+          FROM notification_requests
+          WHERE id IN(
+            SELECT distinct on (notification_request_id) notification_request_id
+            FROM notification_request_statuses
+            WHERE created_at <= ?
+            ORDER BY notification_request_id, created_at
+          ) AND status = ?
+        ",
+        DateTime.now - NotificationRequest::DAYS_TO_BE_CONSIDERED_INACTIVE,
+        STATUSES[:ACTIVE]
+      ]
+    )
   }
 end

--- a/spec/models/notification_request_spec.rb
+++ b/spec/models/notification_request_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe NotificationRequest do
   context 'when it is inactive' do
     before(:each) do
       create_list(
-        :notification_request, 2, status: NotificationRequest::STATUSES[:ACTIVE]
+        :notification_request, 1, status: NotificationRequest::STATUSES[:ACTIVE]
       ).each do |nr|
         create(
           :notification_request_status, notification_request: nr, created_at: DateTime.now
@@ -93,6 +93,24 @@ RSpec.describe NotificationRequest do
 
       create_list(
         :notification_request, 2, status: NotificationRequest::STATUSES[:ACTIVE]
+      ).each do |nr|
+        create(
+          :notification_request_status,
+          notification_request: nr,
+          created_at: DateTime.now - NotificationRequest::DAYS_TO_BE_CONSIDERED_INACTIVE
+        )
+      end
+
+      create_list(
+        :notification_request, 3, status: NotificationRequest::STATUSES[:DONE]
+      ).each do |nr|
+        create(
+          :notification_request_status, notification_request: nr, created_at: DateTime.now
+        )
+      end
+
+      create_list(
+        :notification_request, 4, status: NotificationRequest::STATUSES[:DONE]
       ).each do |nr|
         create(
           :notification_request_status,


### PR DESCRIPTION
The scope was not considering the status on the query

## Motivation

The scope was not considering the status on the query, so even the `NotificationRequest`s that were `DONE`, where being included.

## Changelog

- Include the status on `NotificationRequest.inactive` query
- Improve misleading tests
