### PR TITLE
Protect essential resources endpoints with a shared token

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,7 @@ NOTIFICATION_REQUEST_UPDATE_PUBLISHER_ARN=
 # Mailing
 EMAIL_DEFAULT_SENDER=
 SENDGRID_API_KEY=
+
+#API
+## Token to protect endpoints that can create/destroy essential resources
+SHARED_SECRET=

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Topic's arn to publish messages when a `NotificationRequest` needs to re-checked
 #### `SENDGRID_API_KEY`
 [Sendgrid](https://sendgrid.com) API key to send emails
 
+#### `SHARED_SECRET`
+Token to protect endpoints that can create/destroy essential resources
+
 ### Database Setup
 
 To create and setup both development and test databases, run:

--- a/app.rb
+++ b/app.rb
@@ -41,6 +41,8 @@ get '/delivery_companies' do
 end
 
 post '/delivery_companies' do
+  protected!
+
   content_type :json
 
   begin
@@ -53,6 +55,8 @@ post '/delivery_companies' do
 end
 
 delete '/delivery_companies/:id' do
+  protected!
+
   begin
     status 204
     DeliveryCompaniesController.delete(params['id'])
@@ -62,11 +66,15 @@ delete '/delivery_companies/:id' do
 end
 
 post '/reminders/update_notification_requests' do
+  protected!
+
   status 204
   RemindersController.new.update_notification_requests
 end
 
 post '/reminders/close_inactive_notification_requests' do
+  protected!
+
   status 204
   RemindersController.new.close_inactive_notification_requests
 end
@@ -98,6 +106,8 @@ post '/notification_requests' do
 end
 
 post '/notification_requests/:id/status' do
+  protected!
+
   controller_params = {
     'notification_request_id' => params['id'],
     'content' => parsed_request_body['content']
@@ -122,5 +132,9 @@ end
 helpers do
   def show_errors_for_field(errors, field_name)
     errors[field_name].join(',') if errors&.dig(field_name)
+  end
+
+  def protected!
+    halt 401 if request.env['SHARED-SECRET'] != ENV['SHARED_SECRET']
   end
 end

--- a/infra/lambdas/remind_close_inactive_notification_requests/lambda_function.rb
+++ b/infra/lambdas/remind_close_inactive_notification_requests/lambda_function.rb
@@ -10,5 +10,6 @@ def lambda_handler(event:, context:)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
   request = Net::HTTP::Post.new(uri.request_uri)
+  request['SHARED-SECRET'] = ENV['SHARED_SECRET']
   http.request(request)
 end

--- a/infra/lambdas/remind_update_notification_requests/lambda_function.rb
+++ b/infra/lambdas/remind_update_notification_requests/lambda_function.rb
@@ -10,5 +10,6 @@ def lambda_handler(event:, context:)
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true
   request = Net::HTTP::Post.new(uri.request_uri)
+  request['SHARED-SECRET'] = ENV['SHARED_SECRET']
   http.request(request)
 end

--- a/infra/lambdas/update_notification_request/lambda_function.rb
+++ b/infra/lambdas/update_notification_request/lambda_function.rb
@@ -31,6 +31,7 @@ def send_status_to_backend(status, destiny_url, notification_request_id)
   http.use_ssl = true
   request = Net::HTTP::Post.new(uri.request_uri)
   request.body = { content: status }.to_json
+  request['SHARED-SECRET'] = ENV['SHARED_SECRET']
   http.request(request)
 end
 

--- a/spec/requests/delivery_companies/create_spec.rb
+++ b/spec/requests/delivery_companies/create_spec.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require_relative '../../../app/models/delivery_company.rb'
+require_relative '../../factories/delivery_company.rb'
 
 RSpec.describe 'POST /delivery_companies' do
   context 'given a POST request to /delivery_companies' do
-    let(:request) { post '/delivery_companies', request_body.to_json }
+    let(:request) do
+      post '/delivery_companies',
+           request_body.to_json,
+           'SHARED-SECRET' => ENV['SHARED_SECRET']
+    end
 
     context 'when the request body is valid' do
       let(:request_body) { { name: 'company name' } }

--- a/spec/requests/delivery_companies/delete_spec.rb
+++ b/spec/requests/delivery_companies/delete_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require_relative '../../factories/delivery_company.rb'
+
 require_relative '../../../app/models/delivery_company.rb'
 
 RSpec.describe 'DELETE /delivery_companies/:id' do
   context 'given a DELETE request to /delivery_companies/:id' do
-    let(:request) { delete "/delivery_companies/#{delivery_company.id}" }
+    let(:request) do
+      delete "/delivery_companies/#{delivery_company.id}",
+             nil,
+             'SHARED-SECRET' => ENV['SHARED_SECRET']
+    end
 
     context 'when the entity exists' do
       let!(:delivery_company) { create(:delivery_company) }

--- a/spec/requests/delivery_companies/index_spec.rb
+++ b/spec/requests/delivery_companies/index_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../factories/delivery_company.rb'
+
 RSpec.describe 'GET /delivery_companies' do
   context 'given a GET request to /delivery_companies' do
     let(:subjet) { get '/delivery_companies' }

--- a/spec/requests/notification_requests/create_status_spec.rb
+++ b/spec/requests/notification_requests/create_status_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'POST /notification_requests/:id/status' do
   context 'given a POST request to /notification_requests/:id/status' do
     let(:request) do
       post "/notification_requests/#{notification_request_id}/status",
-           request_body.to_json
+           request_body.to_json,
+           'SHARED-SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'when the id on the url is valid' do

--- a/spec/requests/reminders/close_inactive_notification_requests_spec.rb
+++ b/spec/requests/reminders/close_inactive_notification_requests_spec.rb
@@ -7,7 +7,11 @@ require_relative '../../../app/helpers/notification_request_finisher.rb'
 
 RSpec.describe 'POST /reminders/update_notification_requests' do
   context 'when receiving a request to remind to update notification requests' do
-    let(:request) { post '/reminders/close_inactive_notification_requests' }
+    let(:request) do
+      post '/reminders/close_inactive_notification_requests',
+           nil,
+           'SHARED-SECRET' => ENV['SHARED_SECRET']
+    end
 
     context 'and there are inactive notification requests' do
       before(:each) do

--- a/spec/requests/reminders/update_notification_requests_spec.rb
+++ b/spec/requests/reminders/update_notification_requests_spec.rb
@@ -6,7 +6,11 @@ require_relative '../../../infra/sns/notification_request_update_publisher.rb'
 
 RSpec.describe 'POST /reminders/update_notification_requests' do
   context 'when receiving a request to remind to update notification requests' do
-    let(:request) { post '/reminders/update_notification_requests' }
+    let(:request) do
+      post '/reminders/update_notification_requests',
+           nil,
+           'SHARED-SECRET' => ENV['SHARED_SECRET']
+    end
 
     context 'and there are active notification requests' do
       before(:each) do

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -10,6 +10,7 @@ resource "aws_lambda_function" "notification_request_update" {
   environment {
     variables = {
       BACKEND_URL = var.lambda_backend_url
+      SHARED_SECRET = var.lambda_shared_secret
     }
   }
 }
@@ -26,6 +27,7 @@ resource "aws_lambda_function" "remind_update_notification_requests" {
   environment {
     variables = {
       BACKEND_URL = var.lambda_backend_url
+      SHARED_SECRET = var.lambda_shared_secret
     }
   }
 }
@@ -41,6 +43,7 @@ resource "aws_lambda_function" "remind_close_inactive_notification_requests" {
   environment {
     variables = {
       BACKEND_URL = var.lambda_backend_url
+      SHARED_SECRET = var.lambda_shared_secret
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -70,7 +70,12 @@ variable "lambda_notification_request_update_timeout" {
 }
 
 variable "lambda_backend_url" {
-  description = "The backend url used in lambda notification_request_update"
+  description = "The backend url used in lambdas"
+  type        = string
+}
+
+variable "lambda_shared_secret" {
+  description = "The shared secret used in lambdas to communicate with the backend"
   type        = string
 }
 


### PR DESCRIPTION
## Motivation

To protect endpoints that can create/destroy essential resources, we need to make sure that whoever is making the request, is authorized

## Changelog

- Add `protected!` helper, so every route with this helper will check if the `SHARED-SECRET` header is equal to `SHARED_SECRET` env var, if it is not, a 401 error will return
- Add the secret on AWS lambdas
    - This is a var that is not on `.tfvars` file because those endpoints should not receive public requests
