### PR TITLE
Allow logging, with :puts, to write on STDOUT

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+$stdout.sync = true
+
 require './app.rb'
 
 run Sinatra::Application


### PR DESCRIPTION
## Motivation

`puts` was not logging on production environment, but with `STDOUT.sync = true`, this make the logging works

More info on [this stakoverflow discussion](https://stackoverflow.com/questions/29998728/what-stdout-sync-true-means/29998780) ot [this heroku article](https://devcenter.heroku.com/articles/logging#writing-to-your-log)

## Changelog

- Disable any log buffering from the app, with `$stdout.sync = true`
