### PR TITLE
Fix how SHARED-SECRET comes in request header

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -135,6 +135,7 @@ helpers do
   end
 
   def protected!
-    halt 401 if request.env['SHARED-SECRET'] != ENV['SHARED_SECRET']
+    # Request headers have a "HTTP" sufix, are all upper and snake case
+    halt 401 if request.env['HTTP_SHARED_SECRET'] != ENV['SHARED_SECRET']
   end
 end

--- a/spec/requests/delivery_companies/create_spec.rb
+++ b/spec/requests/delivery_companies/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'POST /delivery_companies' do
     let(:request) do
       post '/delivery_companies',
            request_body.to_json,
-           'SHARED-SECRET' => ENV['SHARED_SECRET']
+           'HTTP_SHARED_SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'when the request body is valid' do

--- a/spec/requests/delivery_companies/delete_spec.rb
+++ b/spec/requests/delivery_companies/delete_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'DELETE /delivery_companies/:id' do
     let(:request) do
       delete "/delivery_companies/#{delivery_company.id}",
              nil,
-             'SHARED-SECRET' => ENV['SHARED_SECRET']
+             'HTTP_SHARED_SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'when the entity exists' do

--- a/spec/requests/notification_requests/create_status_spec.rb
+++ b/spec/requests/notification_requests/create_status_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'POST /notification_requests/:id/status' do
     let(:request) do
       post "/notification_requests/#{notification_request_id}/status",
            request_body.to_json,
-           'SHARED-SECRET' => ENV['SHARED_SECRET']
+           'HTTP_SHARED_SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'when the id on the url is valid' do

--- a/spec/requests/reminders/close_inactive_notification_requests_spec.rb
+++ b/spec/requests/reminders/close_inactive_notification_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'POST /reminders/update_notification_requests' do
     let(:request) do
       post '/reminders/close_inactive_notification_requests',
            nil,
-           'SHARED-SECRET' => ENV['SHARED_SECRET']
+           'HTTP_SHARED_SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'and there are inactive notification requests' do

--- a/spec/requests/reminders/update_notification_requests_spec.rb
+++ b/spec/requests/reminders/update_notification_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'POST /reminders/update_notification_requests' do
     let(:request) do
       post '/reminders/update_notification_requests',
            nil,
-           'SHARED-SECRET' => ENV['SHARED_SECRET']
+           'HTTP_SHARED_SECRET' => ENV['SHARED_SECRET']
     end
 
     context 'and there are active notification requests' do


### PR DESCRIPTION
## Motivation

Sinatra applies a suffix "HTTP" to requests headers, so, when using a protected endpoint, we should check for HTTP_SHARED_SECRET header

## Changelog

Rename header getter from `SHARED_SECRET` to `HTTP_SHARED_SECRET`
