### PR TITLE
Add Jadlog delivery company to lambda

### DIFF
--- a/infra/lambdas/update_notification_request/lambda_function.rb
+++ b/infra/lambdas/update_notification_request/lambda_function.rb
@@ -48,4 +48,6 @@ class StatusRetriever
       parsed_page.css('.explore-content').text.gsub(/\s+/, '')
     end
   end
+
+  class Jadlog < Correios; end
 end


### PR DESCRIPTION
## Motivation

We are going to support Jadlog pacakges, when getting a it's statuses.

As Jadlog behaves exaclty like Correios to track the package, we are using the same code to do it

## Changelog

Adds `Jadlog` class to `update_notification_request` lambda
